### PR TITLE
TAUSurfaceDataloader Bugfix

### DIFF
--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -222,7 +222,7 @@ class TAUBase(Dataloader):
         dimension n_points x 4; the first three columns correspond to the x/y/z
         coordinates, and the 4th column contains the volumes/areas.
         """
-    pass
+        pass
 
     def load_snapshot(self, field_name: Union[List[str], str],
                       time: Union[List[str], str]) -> Union[List[pt.Tensor], pt.Tensor]:
@@ -531,7 +531,7 @@ class TAUSurfaceDataloader(TAUBase):
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         with Dataset(self._file_name(time)) as data:
-            global_ids = pt.from_numpy(data.variables["global_id"][:])
+            global_ids = pt.from_numpy(data.variables["global_id"][:]).type(pt.int64)
             ids = pt.where(pt.isin(global_ids, self.zone_ids[self.zone]))[0].numpy()
             field = pt.tensor(
                 data.variables[field_name][:], dtype=self._dtype)

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -496,8 +496,10 @@ class TAUSurfaceDataloader(TAUBase):
                     expanded[:, 3] = float("nan")
                     merged = pt.unique(
                         pt.cat((expanded, surface_quad), dim=0)[marker_selection].flatten())
-                    self._zone_ids[zone_name] = merged[~pt.isnan(
-                        merged)].type(pt.int64)
+                    
+                    sorted, indices = pt.sort(merged[~pt.isnan(
+                        merged)].type(pt.int64))
+                    self._zone_ids[zone_name] = sorted
                     del expanded, merged
                 elif surface_tri is not None:
                     self._zone_ids[zone_name] = pt.unique(

--- a/flowtorch/data/tau_dataloader.py
+++ b/flowtorch/data/tau_dataloader.py
@@ -533,7 +533,7 @@ class TAUSurfaceDataloader(TAUBase):
 
     def _load_single_snapshot(self, field_name: str, time: str) -> pt.Tensor:
         with Dataset(self._file_name(time)) as data:
-            global_ids = pt.from_numpy(data.variables["global_id"][:]).type(pt.int64)
+            global_ids = pt.from_numpy(data.variables["global_id"][:])
             ids = pt.where(pt.isin(global_ids, self.zone_ids[self.zone]))[0].numpy()
             field = pt.tensor(
                 data.variables[field_name][:], dtype=self._dtype)


### PR DESCRIPTION
In case of mixed elements (surface-tris and surface-quads) the `self._zone_ids` array was returned unsorted. Therefore the index positions did not match correctly with the `global_ids` of the points in the mesh. This is now corrected.